### PR TITLE
Semantics: Configuring firewall -> Finding an available port

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -52,7 +52,7 @@ ynh_app_setting_set --app=$app --key=is_public --value=$is_public
 #=================================================
 # FIND AND OPEN A PORT
 #=================================================
-ynh_script_progression --message="Configuring firewall..."  --weight=1
+ynh_script_progression --message="Finding an available port..."  --weight=1
 
 # Find an available port
 port=$(ynh_find_port --port=3000)


### PR DESCRIPTION
## Problem

I'm obsessed with semantics and noticed once again that in ~30+ apps we talk about 'Configuring firewall' while this actually has nothing to do with firewall but with finding an available port for internal reverse proxying ...

## Solution

You probably just copypasted this from the example app (which is now also fixed) but I'm just going through all the affected repo to fix this because yeah >_> ...